### PR TITLE
Remove all events implemented with batch

### DIFF
--- a/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
+++ b/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
@@ -407,7 +407,11 @@ export class FullCalendar extends PolymerElement {
 
 
     removeAllEvents() {
-        this.getCalendar().getEvents().forEach(e => e.remove());
+        //this.getCalendar().getEvents().forEach(e => e.remove());
+    	var calendar = this.getCalendar();
+    	this.getCalendar().batchRendering(function() {
+    		calendar.getEvents().forEach(e => e.remove());		  
+		});
     }
 
 


### PR DESCRIPTION
Remove all events implemented with batch, to dramatically improve performances.

According fullcalendar doc it is necessary to use batch for multiple rendering operations.
See https://fullcalendar.io/docs/Calendar-batchRendering