### PR TITLE
Fix drag&drop event between days on the same resource

### DIFF
--- a/addon-scheduler/src/main/java/org/vaadin/stefan/fullcalendar/EntryDroppedSchedulerEvent.java
+++ b/addon-scheduler/src/main/java/org/vaadin/stefan/fullcalendar/EntryDroppedSchedulerEvent.java
@@ -21,15 +21,17 @@ public class EntryDroppedSchedulerEvent extends EntryTimeChangedEvent {
      */
     public EntryDroppedSchedulerEvent(FullCalendarScheduler source, boolean fromClient,
                                       @EventData("event.detail.data") JsonObject jsonEntry,
-                                      @EventData("event.detail.delta") JsonObject jsonDelta) {
+                                      @EventData("event.detail.delta") JsonObject jsonDelta,
+                                      @EventData("event.detail.oldResource") String oldResourceId,
+                              		  @EventData("event.detail.newResource") String newResourceId) {
         super(source, fromClient, jsonEntry, jsonDelta);
 
-        String oldResourceId = jsonEntry.getString("oldResource");
+        //String oldResourceId = jsonEntry.getString("oldResource");
         if (oldResourceId != null) {
             this.oldResource = source.getResourceById(oldResourceId).orElseThrow(IllegalArgumentException::new);
         }
 
-        String newResourceId = jsonEntry.getString("newResource");
+        //String newResourceId = jsonEntry.getString("newResource");
         if (newResourceId != null) {
             this.newResource = source.getResourceById(newResourceId).orElseThrow(IllegalArgumentException::new);
         }


### PR DESCRIPTION
Fix drag&drop event between days on the same resource. 
It was previously fixed by sonnessa commit, removing oldResourceId and newResourceId from the method parameters broke it again.