### PR TITLE
Tooltip and doc fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,16 +298,19 @@ customElements.define('my-full-calendar', MyFullCalendar);
 ```
 
 ### Modifying eventRender from server side
-// The given string will be interpreted as js function on client side
-// and attached as eventRender callback. 
-// Make sure, that it does not contain any harmful code.
+The given string will be interpreted as js function on client side
+and attached as eventRender callback. 
+Make sure, that it does not contain any harmful code.
 
+```
 calendar.setEntryRenderCallback("" +
-        "function(event, element) {" +
-        "   console.log(event.title + 'X');" +
-        "   element.css('color', 'red');" +
-        "   return element; " +
-        "}");
+	"function(info) {" +
+        "   console.log(info.event.title + 'X');" +
+        "   info.el.style.color = 'red';" +
+        "   return info.el; " +
+        "}"
+);
+```
         
 ### Creating a subclass of FullCalendar for custom mods
 1. Create a custom Polymer component

--- a/demo/frontend/full-calendar-with-tooltip.js
+++ b/demo/frontend/full-calendar-with-tooltip.js
@@ -30,7 +30,7 @@ export class FullCalendarWithTooltip extends FullCalendarScheduler {
     }
 
     callTooltip(info) {
-        if (info.event.extendedProps && info.event.extendedProps.description) {
+        if (info.event.extendedProps && info.event.extendedProps.description && !info.isMirror) {
             tippy(info.el, {
                 // content: info.event.extendedProps.description
                 theme: 'light',


### PR DESCRIPTION
Document update for the issue #60 .

Fix for the tooltip duplication issue #61 

The problem is that the `eventRender`, render all the events all the time, so reading the [docs  ](https://fullcalendar.io/docs/eventRender) there is a property called `isMirror`.

`isMirror`: `true `if the element being rendered is a “mirror” from a user **drag, resize, or selection** (see selectMirror). `false `otherwise. 

Essentialy ignoring the event that are considered "mirror" you resolve the problem 