### PR TITLE
Upgrade to V5

### DIFF
--- a/addon-scheduler/src/main/java/org/vaadin/stefan/fullcalendar/FullCalendarScheduler.java
+++ b/addon-scheduler/src/main/java/org/vaadin/stefan/fullcalendar/FullCalendarScheduler.java
@@ -36,8 +36,8 @@ import java.util.stream.StreamSupport;
  * Please visit <a href="https://fullcalendar.io/">https://fullcalendar.io/</a> for details about the client side
  * component, API, functionality, etc.
  */
-@NpmPackage(value = "@fullcalendar/resource-timeline", version = "^4.3.0")
-@NpmPackage(value = "@fullcalendar/resource-timegrid", version = "^4.3.0")
+@NpmPackage(value = "@fullcalendar/resource-timeline", version = "5.3.1")
+@NpmPackage(value = "@fullcalendar/resource-timegrid", version = "5.3.1")
 @Tag("full-calendar-scheduler")
 @JsModule("./full-calendar-scheduler.js")
 public class FullCalendarScheduler extends FullCalendar implements Scheduler {

--- a/addon/src/main/java/org/vaadin/stefan/fullcalendar/FullCalendar.java
+++ b/addon/src/main/java/org/vaadin/stefan/fullcalendar/FullCalendar.java
@@ -39,15 +39,15 @@ import java.util.stream.Stream;
  * Please visit <a href="https://fullcalendar.io/">https://fullcalendar.io/</a> for details about the client side
  * component, API, functionality, etc.
  */
-@NpmPackage(value = "@fullcalendar/core", version = "4.4.2")
-@NpmPackage(value = "@fullcalendar/interaction", version = "4.4.2")
-@NpmPackage(value = "@fullcalendar/daygrid", version = "4.4.2")
-@NpmPackage(value = "@fullcalendar/timegrid", version = "4.4.2")
-@NpmPackage(value = "@fullcalendar/list", version = "4.4.2")
+@NpmPackage(value = "@fullcalendar/core", version = "5.3.1")
+@NpmPackage(value = "@fullcalendar/interaction", version = "5.3.1")
+@NpmPackage(value = "@fullcalendar/daygrid", version = "5.3.1")
+@NpmPackage(value = "@fullcalendar/timegrid", version = "5.3.1")
+@NpmPackage(value = "@fullcalendar/list", version = "5.3.1")
 @NpmPackage(value = "moment", version = "2.24.0")
 @NpmPackage(value = "moment-timezone", version = "0.5.28")
-@NpmPackage(value = "@fullcalendar/moment", version = "4.4.2")
-@NpmPackage(value = "@fullcalendar/moment-timezone", version = "4.4.2")
+@NpmPackage(value = "@fullcalendar/moment", version = "5.3.1")
+@NpmPackage(value = "@fullcalendar/moment-timezone", version = "5.3.1")
 @Tag("full-calendar")
 @JsModule("./full-calendar.js")
 public class FullCalendar extends Component implements HasStyle, HasSize {
@@ -714,8 +714,20 @@ public class FullCalendar extends Component implements HasStyle, HasSize {
      *
      * @param s js function to be attached to eventRender callback
      */
-    public void setEntryRenderCallback(String s) {
-        getElement().callJsFunction("setEventRenderCallback", s);
+    public void setEntryClassNamesCallback(String s) {
+        getElement().callJsFunction("setEventClassNamesCallback", s);
+    }
+    
+    public void setEntryContentCallback(String s) {
+        getElement().callJsFunction("setEventContentCallback", s);
+    }
+    
+    public void setEventDidMountCallback(String s) {
+        getElement().callJsFunction("setEventDidMountCallback", s);
+    }
+    
+    public void setEventWillUnmountCallback(String s) {
+        getElement().callJsFunction("setEventWillUnmountCallback", s);
     }
 
     /**

--- a/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
+++ b/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
@@ -1,15 +1,3 @@
-import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
-import {afterNextRender} from '@polymer/polymer/lib/utils/render-status.js';
-
-import {Calendar} from '@fullcalendar/core';
-import interaction from '@fullcalendar/interaction';
-import dayGridPlugin from '@fullcalendar/daygrid';
-import timeGridPlugin from '@fullcalendar/timegrid';
-import listPlugin from '@fullcalendar/list';
-import {toMoment} from '@fullcalendar/moment'; // only for formatting
-import momentTimezonePlugin from '@fullcalendar/moment-timezone';
-import allLocales from '@fullcalendar/core/locales-all.min';
-
 /*
    Copyright 2020, Stefan Uebe
 
@@ -28,6 +16,19 @@ import allLocales from '@fullcalendar/core/locales-all.min';
 
    Exception of this license is the separately licensed part of the styles.
 */
+
+import {html, PolymerElement} from '@polymer/polymer/polymer-element.js';
+import {afterNextRender} from '@polymer/polymer/lib/utils/render-status.js';
+
+import {Calendar} from '@fullcalendar/core';
+import interaction from '@fullcalendar/interaction';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import listPlugin from '@fullcalendar/list';
+import { toMoment } from '@fullcalendar/moment'; // only for formatting
+import momentTimezonePlugin from '@fullcalendar/moment-timezone';
+import allLocales from '@fullcalendar/core/locales-all.js';
+
 
 export class FullCalendar extends PolymerElement {
     static get template() {
@@ -70,7 +71,7 @@ export class FullCalendar extends PolymerElement {
 
     static get properties() {
         return {
-            eventLimit: {
+        	dayMaxEventRows: {
                 type: Object,
                 value: false
             },
@@ -200,7 +201,7 @@ export class FullCalendar extends PolymerElement {
                     // newResource: eventInfo.newResource ? eventInfo.newResource.id : null
                 }
             },
-            datesRender: (eventInfo) => {
+            datesSet: (eventInfo) => {
                 if (!this.noDatesRenderEvent) {
                     let view = eventInfo.view;
                     return {
@@ -226,12 +227,12 @@ export class FullCalendar extends PolymerElement {
                     allDay: true
                 }
             },
-            eventLimitClick: (eventInfo) => {
+            moreLinkClick: (eventInfo) => {
                 return {
                     date: this._formatDate(eventInfo.date, true)
                 }
             },
-            viewSkeletonRender: (eventInfo) => {
+            viewDidMount: (eventInfo) => {
                 let view = eventInfo.view;
                 return {
                     name: view.type,
@@ -307,9 +308,9 @@ export class FullCalendar extends PolymerElement {
             timeZone: 'UTC',
 
             // // no native control elements
-            header: false,
+            headerToolbar: false,
             weekNumbers: true,
-            eventLimit: this.eventLimit,
+            dayMaxEventRows: this.dayMaxEventRows,
             navLinks: this.navLinks,
             selectable: this.selectable,
         };
@@ -455,7 +456,7 @@ export class FullCalendar extends PolymerElement {
 
                         for (let property in obj) {
                             if (property !== 'id' && property !== "start" && property !== "end" && property !== "allDay") {
-                                eventToUpdate.setProp(property, obj[property]);
+                                eventToUpdate.setExtendedProp(property, obj[property]);
                             }
                         }
                     }
@@ -494,7 +495,6 @@ export class FullCalendar extends PolymerElement {
         }
     }
 
-
     removeAllEvents() {
         //this.getCalendar().getEvents().forEach(e => e.remove());
         var calendar = this.getCalendar();
@@ -502,7 +502,6 @@ export class FullCalendar extends PolymerElement {
             calendar.getEvents().forEach(e => e.remove());
         });
     }
-
 
     changeView(viewName) {
         this.getCalendar().changeView(viewName);
@@ -512,11 +511,25 @@ export class FullCalendar extends PolymerElement {
         this.getCalendar().render();
     }
 
-    setEventRenderCallback(s) {
+    setEventClassNamesCallback(s) {
         let calendar = this.getCalendar();
-        calendar.setOption('eventRender', new Function("return " + s)());
+        calendar.setOption('eventClassNames', new Function("return " + s)());
     }
-
+    
+    setEventContentCallback(s) {
+        let calendar = this.getCalendar();
+        calendar.setOption('eventContent', new Function("return " + s)());
+    }
+    
+    setEventDidMountCallback(s) {
+        let calendar = this.getCalendar();
+        calendar.setOption('eventDidMount', new Function("return " + s)());
+    }
+    
+    setEventWillUnmountCallback(s) {
+        let calendar = this.getCalendar();
+        calendar.setOption('eventWillUnmount', new Function("return " + s)());
+    }
 }
 
 customElements.define("full-calendar", FullCalendar);

--- a/demo/frontend/full-calendar-with-tooltip.js
+++ b/demo/frontend/full-calendar-with-tooltip.js
@@ -26,7 +26,7 @@ export class FullCalendarWithTooltip extends FullCalendarScheduler {
 
     _initCalendar() {
         super._initCalendar();
-        this.getCalendar().setOption("eventRender", this.callTooltip);
+        this.getCalendar().setOption("eventDidMount", this.callTooltip);
     }
 
     callTooltip(info) {

--- a/demo/src/main/java/org/vaadin/stefan/MainView.java
+++ b/demo/src/main/java/org/vaadin/stefan/MainView.java
@@ -22,13 +22,11 @@ import com.vaadin.flow.component.orderedlayout.FlexComponent;
 import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
 import com.vaadin.flow.component.orderedlayout.VerticalLayout;
 import com.vaadin.flow.component.page.Push;
-import com.vaadin.flow.component.page.Viewport;
 import com.vaadin.flow.router.PageTitle;
 import com.vaadin.flow.router.RouterLayout;
 
 @Push
 @PageTitle("FullCalendar Demo")
-@Viewport("width=100vw, height=100vh")
 public class MainView extends VerticalLayout implements RouterLayout {
 
     public MainView() {
@@ -39,7 +37,7 @@ public class MainView extends VerticalLayout implements RouterLayout {
 
         HorizontalLayout title = new HorizontalLayout();
 
-        title.add(new H3("FullCalendar demo"), new Span("(Vaadin 14.3.4, FullCalendar addon: 2.3.4-SNAPSHOT (uses FC 4.4.2), FullCalendar Scheduler extension: 2.3.4-SNAPSHOT (uses scheduler extension libs 4.3.0)"));
+        title.add(new H3("FullCalendar demo"), new Span("(Vaadin 14.3.4, FullCalendar addon: 2.3.4-SNAPSHOT (uses FC 5.3.1), FullCalendar Scheduler extension: 2.3.4-SNAPSHOT (uses scheduler extension libs 5.3.1)"));
         title.setDefaultVerticalComponentAlignment(FlexComponent.Alignment.BASELINE);
 
         add(title);


### PR DESCRIPTION
According to the [upgrade guide ](https://fullcalendar.io/docs/upgrading-from-v4) I made some changes to:

*  Renamed all the options that has changed the name
*  Changed the `eventRender` with the new event render hooks.
*  Removed the ViewPort

Actually I'm stuck on the CSS conversion. Reading the guide chapter **CSS and DOM Structure** it talk about a *className-upgrade document* that I can't find anywhere.
