### PR TITLE
support eventMouseEnter + eventMouseLeave

### DIFF
--- a/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
+++ b/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
@@ -273,6 +273,20 @@ export class FullCalendar extends PolymerElement {
                     data: this._toEventData(event)
                 }
             },
+            eventMouseEnter: (eventInfo) => {
+                let event = eventInfo.event;
+                return {
+                    id: event.id, 
+                    data: this._toEventData(event)
+                }
+            },
+            eventMouseLeave: (eventInfo) => {
+                let event = eventInfo.event;
+                return {
+                    id: event.id, 
+                    data: this._toEventData(event)
+                }
+            },
             eventResize: (eventInfo) => {
                 return {
                     data: this._toEventData(eventInfo.event),

--- a/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
+++ b/addon/src/main/resources/META-INF/resources/frontend/full-calendar.js
@@ -276,14 +276,12 @@ export class FullCalendar extends PolymerElement {
             eventMouseEnter: (eventInfo) => {
                 let event = eventInfo.event;
                 return {
-                    id: event.id, 
                     data: this._toEventData(event)
                 }
             },
             eventMouseLeave: (eventInfo) => {
                 let event = eventInfo.event;
                 return {
-                    id: event.id, 
                     data: this._toEventData(event)
                 }
             },


### PR DESCRIPTION
[Issue 147](https://github.com/stefanuebe/vaadin_fullcalendar/issues/147)

As discussed, this is the PR. I'm not sure about the 

```
data: this._toEventData(event)
``` 

Please let me know if there is more to do.

